### PR TITLE
HTML escaping for HTML elements, attributes and CData nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/*
 /target/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,12 @@
-
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.irenical</groupId>
     <artifactId>leek</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.7</version>
+
     <packaging>jar</packaging>
 
     <name>leek</name>
@@ -14,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-  
+
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/com/irenical/leek/utils/TextEncoder.java
+++ b/src/main/java/com/irenical/leek/utils/TextEncoder.java
@@ -1,0 +1,45 @@
+/*
+	This file is part of Leek.
+
+    Leek is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Leek is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Leek.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.irenical.leek.utils;
+
+public class TextEncoder {
+    public static String encodeHTML(String or) {
+        or = or.replace("&" , "&amp;");
+        or = or.replace("<",  "&lt;");
+        or = or.replace(">",  "&gt;");
+        or = or.replace("\"", "&quot;");
+        or = or.replace("\'", "&#x27;");
+        or = or.replace("/",  "&#x2F;");
+
+        return or;
+    }
+
+    public static String encodeHTMLAttrSimple(String or) {
+        or = or.replace("&",  "&amp;");
+        or = or.replace("<",  "&lt;");
+        or = or.replace(">",  "&gt;");
+        or = or.replace("\"", "&quot;");
+        or = or.replace("\'", "&#x27;");
+
+        return or;
+    }
+
+    public static String encodeCData(String or) {
+        return or.replace("]]>", "]]]]><![CDATA[>");
+    }
+}

--- a/src/main/java/com/irenical/leek/utils/TextStripper.java
+++ b/src/main/java/com/irenical/leek/utils/TextStripper.java
@@ -20,7 +20,7 @@ package com.irenical.leek.utils;
 
 public class TextStripper {
     public static String alphaOnly(String value) {
-        value = value.replaceAll("[^A-Za-z0-9]", "");
+        value = value.replaceAll("[^A-Za-z0-9-]", "");
 
         if(value.isEmpty())
             return "_";

--- a/src/main/java/com/irenical/leek/utils/TextStripper.java
+++ b/src/main/java/com/irenical/leek/utils/TextStripper.java
@@ -1,0 +1,30 @@
+/*
+	This file is part of Leek.
+
+    Leek is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Leek is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Leek.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.irenical.leek.utils;
+
+
+public class TextStripper {
+    public static String alphaOnly(String value) {
+        value = value.replaceAll("[^A-Za-z0-9]", "");
+
+        if(value.isEmpty())
+            return "_";
+        else
+            return value;
+    }
+}

--- a/src/main/java/com/irenical/leek/view/html/core/HTMLConstants.java
+++ b/src/main/java/com/irenical/leek/view/html/core/HTMLConstants.java
@@ -46,6 +46,16 @@ public interface HTMLConstants {
     public static final String ACTION_KEY = "action";
     
     public static final String METHOD_KEY = "method";
+
+    public static final String  FOR_KEY = "for";
+
+    public static final String  CHECKED_KEY = "checked";
+
+    public static final String  ID_KEY = "id";
+
+    public static final String  NAME_KEY = "name";
+
+    public static final String  TARGET_KEY = "target";
     
     /**
      * ATTRIBUTE VALUES
@@ -58,7 +68,11 @@ public interface HTMLConstants {
     public static final String RADIO_ATTR = "radio";
     
     public static final String SUBMIT_ATTR = "submit";
-    
+
+    public static final String  TRUE_ATTR = "true";
+
+    public static final String  FALSE_ATTR = "false";
+
     /**
      * SYMBOLS
      */

--- a/src/main/java/com/irenical/leek/view/html/core/HTMLTag.java
+++ b/src/main/java/com/irenical/leek/view/html/core/HTMLTag.java
@@ -93,7 +93,7 @@ public class HTMLTag implements HTMLConstants {
 	public static final HTMLTag TABLE = new HTMLTag("table");
 	public static final HTMLTag TBODY = new HTMLTag("tbody");
 	public static final HTMLTag TD = new HTMLTag("td");
-	public static final HTMLTag TEXTAREA = new HTMLTag("textarea");
+	public static final HTMLTag TEXTAREA = new HTMLTag("textarea", false, false, false);
 	public static final HTMLTag TFOOT = new HTMLTag("tfoot");
 	public static final HTMLTag TH = new HTMLTag("th");
 	public static final HTMLTag THEAD = new HTMLTag("thead");

--- a/src/main/java/com/irenical/leek/view/html/core/HTMLTag.java
+++ b/src/main/java/com/irenical/leek/view/html/core/HTMLTag.java
@@ -109,7 +109,7 @@ public class HTMLTag implements HTMLConstants {
 
 	private final String name;
 
-	private final boolean cData;
+	public final boolean cData;
 
 	public HTMLTag(String name) {
 		this(name, true, false, false);
@@ -126,7 +126,7 @@ public class HTMLTag implements HTMLConstants {
 		return name;
 	}
 
-	protected <MODEL_CLASS, CONFIG_CLASS> void htmlOpen(Appendable builder, MODEL_CLASS model, CONFIG_CLASS config, int groupIndex, HTMLAttributes<MODEL_CLASS, CONFIG_CLASS> attributes, boolean selfClosing, boolean isCommented) throws IOException {
+	protected <MODEL_CLASS, CONFIG_CLASS> void htmlOpen(Appendable builder, MODEL_CLASS model, CONFIG_CLASS config, int groupIndex, HTMLAttributes<MODEL_CLASS, CONFIG_CLASS> attributes, boolean selfClosing, boolean isCommented, boolean startedCData) throws IOException {
 		if (isCommented) {
 			builder.append(OPENING_COMMENT);
 		}
@@ -135,13 +135,13 @@ public class HTMLTag implements HTMLConstants {
 			attributes.draw(builder, model, config, groupIndex);
 		}
 		builder.append(selfClosing ? (isCommented ? CLOSING_COMMENT : SELF_CLOSING) : CLOSING_CLOSE);
-		if (cData) {
+		if (cData && startedCData) {
 			builder.append(CDATA_START);
 		}
 	}
 
-	protected void htmlClose(Appendable builder, boolean isCommented) throws IOException {
-		if (cData) {
+	protected void htmlClose(Appendable builder, boolean isCommented, boolean startedCData) throws IOException {
+		if (cData && startedCData) {
 			builder.append(CDATA_END);
 		}
 		builder.append(OPENING_CLOSE);

--- a/src/main/java/com/irenical/leek/view/html/core/HTMLTextNode.java
+++ b/src/main/java/com/irenical/leek/view/html/core/HTMLTextNode.java
@@ -22,6 +22,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import com.irenical.leek.model.ModelTransformer;
+import com.irenical.leek.utils.TextEncoder;
 import com.irenical.leek.view.string.StringView;
 
 public class HTMLTextNode<MODEL_CLASS, CONFIG_CLASS> extends StringView<MODEL_CLASS, CONFIG_CLASS> implements HTMLConstants {
@@ -46,19 +47,21 @@ public class HTMLTextNode<MODEL_CLASS, CONFIG_CLASS> extends StringView<MODEL_CL
 
 	@SuppressWarnings("unchecked")
 	@Override
-	protected void buildString(Appendable builder, MODEL_CLASS model, CONFIG_CLASS config, int groupIndex) throws IOException {
+	protected void buildString(Appendable builder, MODEL_CLASS model, CONFIG_CLASS config, boolean inCData,
+                               boolean noEscape, int groupIndex) throws IOException {
 		if (isVisible(model, config, groupIndex)) {
 			for (Object text : allText) {
 				String stringValue = null;
 				if (text instanceof ModelTransformer<?, ?, ?>) {
 					Object value = ((ModelTransformer<MODEL_CLASS, ?, CONFIG_CLASS>) text).transform(model, config, groupIndex);
-					stringValue = value == null ? null : value.toString();
+					stringValue = (value == null) ? null : value.toString();
 				} else if (text instanceof String) {
 					stringValue = (String) text;
 				}
 				if (stringValue != null) {
-					builder.append(stringValue);
-				}
+                    builder.append(noEscape ? stringValue : TextEncoder.encodeHTML(stringValue));
+                    if(inCData) TextEncoder.encodeCData(stringValue);
+                }
 			}
 		}
 	}

--- a/src/main/java/com/irenical/leek/view/string/StringView.java
+++ b/src/main/java/com/irenical/leek/view/string/StringView.java
@@ -46,10 +46,16 @@ public abstract class StringView<MODEL_CLASS, CONFIG_CLASS> {
 		return result;
 	}
 
-	public final void draw(Appendable builder, MODEL_CLASS model, CONFIG_CLASS config, int groupIndex) throws IOException {
-		buildString(builder, model, config, groupIndex);
-	}
+    public final void draw(Appendable builder, MODEL_CLASS model, CONFIG_CLASS config, int groupIndex) throws IOException {
+        buildString(builder, model, config, false, false, groupIndex);
+    }
 
-	protected abstract void buildString(Appendable builder, MODEL_CLASS model, CONFIG_CLASS config, int groupIndex) throws IOException;
+    public final void draw(Appendable builder, MODEL_CLASS model, CONFIG_CLASS config, boolean inCData, boolean noEscape,
+                           int groupIndex) throws IOException {
+        buildString(builder, model, config, inCData, noEscape, groupIndex);
+    }
+
+	protected abstract void buildString(Appendable builder, MODEL_CLASS model, CONFIG_CLASS config, boolean inCData,
+                                        boolean noEscape, int groupIndex) throws IOException;
 
 }


### PR DESCRIPTION
Escaping is done by default, nodes that need to print straight HTML from inside the model should use setLiteral(true).
